### PR TITLE
updated the main .csproj and he test .csproj to net 9

### DIFF
--- a/UnitTestingExercise.Tests/UnitTestingExercise.Tests.csproj
+++ b/UnitTestingExercise.Tests/UnitTestingExercise.Tests.csproj
@@ -1,20 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.1.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/UnitTestingExercise/UnitTestingExercise.csproj
+++ b/UnitTestingExercise/UnitTestingExercise.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes updates to the target framework and package references in the project files for the `UnitTestingExercise` solution. The changes ensure compatibility with the latest .NET version and update the testing packages to their latest versions.

Framework and package updates:

* [`UnitTestingExercise.Tests/UnitTestingExercise.Tests.csproj`](diffhunk://#diff-c4b10b4876cd9f84ad4a5c70e4ed58910bf781821ed09ecd50b198280494ad1bL4-R17): Updated the target framework from `net6.0` to `net9.0` and upgraded the package references for `Microsoft.NET.Test.Sdk`, `xunit`, `xunit.runner.visualstudio`, and `coverlet.collector` to their latest versions.
* [`UnitTestingExercise/UnitTestingExercise.csproj`](diffhunk://#diff-01d6da37e9f878c0426a84a1b074ba78294a79153e0701e56a58da5669015d3cL5-R5): Updated the target framework from `net6.0` to `net9.0`.


Tested:
Ran build successfully